### PR TITLE
ArgumentNullException in .NET_35

### DIFF
--- a/Keen.NET_35/KeenClient.cs
+++ b/Keen.NET_35/KeenClient.cs
@@ -247,7 +247,7 @@ namespace Keen.NET_35
 
             var keen = ((JObject)jEvent.Property("keen").Value);
 
-            if (addOns.Any())
+            if (null != addOns && addOns.Any())
                 keen.Add("addons", JArray.FromObject(addOns));
 
             // Set the keen.timestamp if it has not already been set


### PR DESCRIPTION
The ```addOns``` param in ```PrepareUserObject``` can be null (default value coming from ```AddEvent``` and ```AddEvents```)
Need to check that before LINQing