### PR TITLE
allow null value as property_value in a QueryFilter

### DIFF
--- a/Keen.NET.Test/QueryTest.cs
+++ b/Keen.NET.Test/QueryTest.cs
@@ -1136,6 +1136,21 @@ namespace Keen.Net.Test
         }
 
         [Test]
+        public void Serialize_NullValue_Success()
+        {
+            var filter = new QueryFilter("prop", QueryFilter.FilterOperator.Equals(), null);
+
+            var json = JObject.FromObject(filter).ToString();
+
+            const string expectedJson = "{\r\n" +
+                                        "  \"property_name\": \"prop\",\r\n" +
+                                        "  \"operator\": \"eq\",\r\n" +
+                                        "  \"property_value\": null\r\n" +
+                                        "}";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
         public void Serialize_SimpleValue_Success()
         {
             var filter = new QueryFilter("prop", QueryFilter.FilterOperator.Equals(), "val");

--- a/Keen/Query/QueryFilter.cs
+++ b/Keen/Query/QueryFilter.cs
@@ -142,8 +142,6 @@ namespace Keen.Core.Query
         {
             if (string.IsNullOrWhiteSpace(property))
                 throw new ArgumentNullException("property");
-            if (null == value)
-                throw new ArgumentNullException("value");
 
             PropertyName = property;
             Operator = op;


### PR DESCRIPTION
Allow null value as property_value in a QueryFilter
Added test: Keen.Net.Test.QueryFilterTest.Serialize_NullValue_Success()
