### PR TITLE
Use the same version of Json.NET for all packages, and update to 9.0.…

### DIFF
--- a/Keen.NET.Test/Keen.NET.Test.csproj
+++ b/Keen.NET.Test/Keen.NET.Test.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/Keen.NET.Test/packages.config
+++ b/Keen.NET.Test/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.2.0" targetFramework="net45" />
   <package id="PCLStorage" version="1.0.2" targetFramework="net45" />
 </packages>

--- a/Keen.NET_35.Test/Keen.NET_35.Test.csproj
+++ b/Keen.NET_35.Test/Keen.NET_35.Test.csproj
@@ -59,8 +59,8 @@
       <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/Keen.NET_35.Test/packages.config
+++ b/Keen.NET_35.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1510.2205" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
   <package id="NUnit" version="3.2.0" targetFramework="net40" />
 </packages>

--- a/Keen.NET_35/Keen.NET_35.csproj
+++ b/Keen.NET_35/Keen.NET_35.csproj
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Keen.NET_35/packages.config
+++ b/Keen.NET_35/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net35" />
   <package id="RestSharp" version="105.2.3" targetFramework="net35" />
 </packages>

--- a/Keen.Net/Keen.Net.csproj
+++ b/Keen.Net/Keen.Net.csproj
@@ -43,8 +43,8 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PCLStorage, Version=1.0.2.0, Culture=neutral, PublicKeyToken=286fe515a2c35b64, processorArchitecture=MSIL">

--- a/Keen.Net/packages.config
+++ b/Keen.Net/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="PCLStorage" version="1.0.2" targetFramework="net45" />
 </packages>

--- a/Keen/Keen.csproj
+++ b/Keen/Keen.csproj
@@ -88,8 +88,8 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net40+sl4+win8+wp71+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PCLStorage, Version=1.0.2.0, Culture=neutral, PublicKeyToken=286fe515a2c35b64, processorArchitecture=MSIL">

--- a/Keen/packages.config
+++ b/Keen/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="portable-net45+sl50+win+wpa81+wp80" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable-net45+sl50+win+wpa81+wp80" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable-net45+sl50+win+wpa81+wp80" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="portable-net45+sl50+win+wpa81+wp80" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
   <package id="PCLStorage" version="1.0.2" targetFramework="portable-net45+sl50+win+wpa81+wp80" />
 </packages>

--- a/KeenClient.nuspec
+++ b/KeenClient.nuspec
@@ -15,7 +15,7 @@
     <tags>keen.io analytics api rest client stats statistics phone wp8</tags>
     <dependencies>
       <group targetFramework="net40">
-        <dependency id="Newtonsoft.Json" version="8.0.3" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
         <dependency id="Microsoft.Net.Http" version="2.2.29" />
         <dependency id="Microsoft.Bcl" version="1.1.10" />
         <dependency id="Microsoft.Bcl.Build" version="1.0.21" />
@@ -24,7 +24,7 @@
       </group>
 
       <group targetFramework="portable-net45+wp8+win8+wpa81+monoandroid+monotouch">
-        <dependency id="Newtonsoft.Json" version="8.0.3" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
         <dependency id="Microsoft.Net.Http" version="2.2.29" />
         <dependency id="Microsoft.Bcl" version="1.1.10" />
         <dependency id="Microsoft.Bcl.Build" version="1.0.21" />
@@ -33,7 +33,7 @@
       </group>
 
       <group targetFramework="net35">
-        <dependency id="Newtonsoft.Json" version="6.0.3" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
         <dependency id="RestSharp" version="104.4.0" />
       </group>
     </dependencies>


### PR DESCRIPTION
…1 while we're at it, which adds support for .NET Core in case we want to expand into .NET Core and .NET Standard as well.
- Fixes Issue #38 