### PR TITLE
AppVeyor CI + Coveralls

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,5 +54,23 @@ matrix:
 
 configuration: Release
 
+build:
+  parallel: true
+
+  # MSBuild verbosity level
+  verbosity: detailed
+
 before_build:
   - nuget restore
+
+
+#---------------------------------#
+#       tests configuration       #
+#---------------------------------#
+
+# Install tools needed for Code Coverage, run instrumented tests, and report coverage numbers
+after_test:
+  - nuget install OpenCover -Version 4.6.519 -OutputDirectory tools
+  - nuget install coveralls.net -Version 0.8.0-unstable0013 -PreRelease -OutputDirectory tools
+  - ./tools/OpenCover.4.6.519/tools/OpenCover.Console.exe -target:nunit3-console.exe -targetargs:"--noheader .\Keen.NET.Test\bin\Release\Keen.Net.Test.dll .\Keen.NET_35.Test\bin\Release\Keen.NET_35.Test.dll" -filter:"+[*]* -[*.Test]*" -register:user
+  - ./tools/coveralls.net.0.8.0-unstable0013/tools/csmacnz.Coveralls.exe --opencover -i ./results.xml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,10 +7,13 @@ version: 1.0.{build}-{branch}
 
 skip_tags: true
 
-# branches to build
-branches:
-  only:
-    - /jm_.*/
+# branches to build, in case we want to whitelist or blacklist some
+#branches:
+#  only:
+#    - /jm_.*/
+
+# We'll probably want to filter branches and also have branch-conditional configs,
+# at which point, look here: https://www.appveyor.com/docs/branches/
 
 # skip commits with a commit message matching this regex
 # note that [skip ci] and [skip appveyor] should work anyway
@@ -21,16 +24,19 @@ branches:
 #---------------------------------#
 #    environment configuration    #
 #---------------------------------#
+
 image:
 - Visual Studio 2015
 - Visual Studio 2017
 
-# scripts that are called at very beginning, before repo cloning
+# scripts that are called at the very beginning, before repo cloning
 init:
   - git config --global core.autocrlf true
 
-# Limit the number of revisions in the history
-clone_depth: 1
+# Limit the number of revisions in the history and download as .zip file. Technically
+# these seem to be mutually exclusive.
+shallow_clone: true
+clone_depth: 5
 
 nuget:  
   disable_publish_on_pr: true
@@ -42,7 +48,7 @@ environment:
 # scripts that run after cloning repository
 install:
   # by default, all script lines are interpreted as batch
-  - echo This is batch
+  #- echo This is batch
 
 matrix:
   fast_finish: true
@@ -74,3 +80,33 @@ after_test:
   - nuget install coveralls.net -Version 0.8.0-unstable0013 -PreRelease -OutputDirectory tools
   - .\tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:nunit3-console.exe -targetargs:"--noheader .\Keen.NET.Test\bin\Release\Keen.Net.Test.dll .\Keen.NET_35.Test\bin\Release\Keen.NET_35.Test.dll" -filter:"+[*]* -[*.Test]*" -register:user
   - .\tools\coveralls.net.0.8.0-unstable0013\tools\csmacnz.Coveralls.exe --opencover -i .\results.xml
+
+
+#---------------------------------#
+#         notifications           #
+#---------------------------------#
+
+# We should consider adding some notifications, e.g.:
+
+#notifications:
+
+  # Email
+#  - provider: Email
+#    to:
+#      - user1@email.com
+#      - user2@email.com
+#    subject: 'Build {{status}}'                  # optional
+#    message: "{{message}}, {{commitId}}, ..."    # optional
+#    on_build_status_changed: true
+
+  # Slack
+#  - provider: Slack
+#    incoming_webhook: http://incoming-webhook-url
+
+  # ...or using auth token
+
+#  - provider: Slack
+#    auth_token:
+#      secure: kBl9BlxvRMr9liHmnBs14A==
+#    channel: development
+#    template: "{message}, {commitId}, ..."

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,5 +72,5 @@ before_build:
 after_test:
   - nuget install OpenCover -Version 4.6.519 -OutputDirectory tools
   - nuget install coveralls.net -Version 0.8.0-unstable0013 -PreRelease -OutputDirectory tools
-  - ./tools/OpenCover.4.6.519/tools/OpenCover.Console.exe -target:nunit3-console.exe -targetargs:"--noheader .\Keen.NET.Test\bin\Release\Keen.Net.Test.dll .\Keen.NET_35.Test\bin\Release\Keen.NET_35.Test.dll" -filter:"+[*]* -[*.Test]*" -register:user
-  - ./tools/coveralls.net.0.8.0-unstable0013/tools/csmacnz.Coveralls.exe --opencover -i ./results.xml
+  - .\tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:nunit3-console.exe -targetargs:"--noheader .\Keen.NET.Test\bin\Release\Keen.Net.Test.dll .\Keen.NET_35.Test\bin\Release\Keen.NET_35.Test.dll" -filter:"+[*]* -[*.Test]*" -register:user
+  - .\tools\coveralls.net.0.8.0-unstable0013\tools\csmacnz.Coveralls.exe --opencover -i .\results.xml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,7 +37,7 @@ nuget:
 
 environment:
   COVERALLS_REPO_TOKEN:
-    secure: <blah>
+    secure: x5HXnLkYkCzK7mWUW6O8QjNAaYNySKhI2Q20oah9i5mvnTk4U8jLJZnVb9MSxx0a
 
 # scripts that run after cloning repository
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,58 @@
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+# version format
+version: 1.0.{build}-{branch}
+
+skip_tags: true
+
+# branches to build
+branches:
+  only:
+    - /jm_.*/
+
+# skip commits with a commit message matching this regex
+# note that [skip ci] and [skip appveyor] should work anyway
+#skip_commits:
+#  message: /\[chore\]/
+
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+image:
+- Visual Studio 2015
+- Visual Studio 2017
+
+# scripts that are called at very beginning, before repo cloning
+init:
+  - git config --global core.autocrlf true
+
+# Limit the number of revisions in the history
+clone_depth: 1
+
+nuget:  
+  disable_publish_on_pr: true
+
+environment:
+  COVERALLS_REPO_TOKEN:
+    secure: <blah>
+
+# scripts that run after cloning repository
+install:
+  # by default, all script lines are interpreted as batch
+  - echo This is batch
+
+matrix:
+  fast_finish: true
+
+
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
+
+configuration: Release
+
+before_build:
+  - nuget restore

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -79,7 +79,7 @@ after_test:
   - nuget install OpenCover -Version 4.6.519 -OutputDirectory tools
   - nuget install coveralls.net -Version 0.8.0-unstable0013 -PreRelease -OutputDirectory tools
   - .\tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:nunit3-console.exe -targetargs:"--noheader .\Keen.NET.Test\bin\Release\Keen.Net.Test.dll .\Keen.NET_35.Test\bin\Release\Keen.NET_35.Test.dll" -filter:"+[*]* -[*.Test]*" -register:user
-  - .\tools\coveralls.net.0.8.0-unstable0013\tools\csmacnz.Coveralls.exe --opencover -i .\results.xml
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( .\tools\coveralls.net.0.8.0-unstable0013\tools\csmacnz.Coveralls.exe --opencover -i .\results.xml )
 
 
 #---------------------------------#

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ If you're here for the #dotnetsummer hackfest, please work out of [this branch](
 keen-sdk-net
 ============
 
+[![Build status](https://ci.appveyor.com/api/projects/status/sxkqpvmlxto07y4r?svg=true)](https://ci.appveyor.com/project/masojus/keen-sdk-net)
+
 Overview
 -----
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ If you're here for the #dotnetsummer hackfest, please work out of [this branch](
 keen-sdk-net
 ============
 
-[![Build status](https://ci.appveyor.com/api/projects/status/sxkqpvmlxto07y4r/branch/master?svg=true)](https://ci.appveyor.com/project/masojus/keen-sdk-net/branch/master) [![Coverage Status](https://coveralls.io/repos/github/keenlabs/keen-sdk-net/badge.svg?branch=master)](https://coveralls.io/github/keenlabs/keen-sdk-net?branch=master)
+[![Build status](https://ci.appveyor.com/api/projects/status/sxkqpvmlxto07y4r/branch/master?svg=true)](https://ci.appveyor.com/project/masojus/keen-sdk-net/branch/master) [![Coverage Status](https://coveralls.io/repos/github/keenlabs/keen-sdk-net/badge.svg?branch=master)](https://coveralls.io/github/keenlabs/keen-sdk-net?branch=master) [![NuGet](http://img.shields.io/nuget/v/KeenClient.svg)](https://www.nuget.org/packages/KeenClient/)
 
 Overview
 -----

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ If you're here for the #dotnetsummer hackfest, please work out of [this branch](
 keen-sdk-net
 ============
 
-[![Build status](https://ci.appveyor.com/api/projects/status/sxkqpvmlxto07y4r/branch/jm_AppVeyorCI?svg=true)](https://ci.appveyor.com/project/masojus/keen-sdk-net/branch/jm_AppVeyorCI) [![Coverage Status](https://coveralls.io/repos/github/keenlabs/keen-sdk-net/badge.svg?branch=jm_AppVeyorCI)](https://coveralls.io/github/keenlabs/keen-sdk-net?branch=jm_AppVeyorCI)
+[![Build status](https://ci.appveyor.com/api/projects/status/sxkqpvmlxto07y4r/branch/master?svg=true)](https://ci.appveyor.com/project/masojus/keen-sdk-net/branch/master) [![Coverage Status](https://coveralls.io/repos/github/keenlabs/keen-sdk-net/badge.svg?branch=master)](https://coveralls.io/github/keenlabs/keen-sdk-net?branch=master)
 
 Overview
 -----

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ If you're here for the #dotnetsummer hackfest, please work out of [this branch](
 keen-sdk-net
 ============
 
-[![Build status](https://ci.appveyor.com/api/projects/status/sxkqpvmlxto07y4r?svg=true)](https://ci.appveyor.com/project/masojus/keen-sdk-net)
+[![Build status](https://ci.appveyor.com/api/projects/status/sxkqpvmlxto07y4r/branch/jm_AppVeyorCI?svg=true)](https://ci.appveyor.com/project/masojus/keen-sdk-net/branch/jm_AppVeyorCI)[![Coverage Status](https://coveralls.io/repos/github/keenlabs/keen-sdk-net/badge.svg?branch=jm_AppVeyorCI)](https://coveralls.io/github/keenlabs/keen-sdk-net?branch=jm_AppVeyorCI)
 
 Overview
 -----

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ If you're here for the #dotnetsummer hackfest, please work out of [this branch](
 keen-sdk-net
 ============
 
-[![Build status](https://ci.appveyor.com/api/projects/status/sxkqpvmlxto07y4r/branch/jm_AppVeyorCI?svg=true)](https://ci.appveyor.com/project/masojus/keen-sdk-net/branch/jm_AppVeyorCI)[![Coverage Status](https://coveralls.io/repos/github/keenlabs/keen-sdk-net/badge.svg?branch=jm_AppVeyorCI)](https://coveralls.io/github/keenlabs/keen-sdk-net?branch=jm_AppVeyorCI)
+[![Build status](https://ci.appveyor.com/api/projects/status/sxkqpvmlxto07y4r/branch/jm_AppVeyorCI?svg=true)](https://ci.appveyor.com/project/masojus/keen-sdk-net/branch/jm_AppVeyorCI) [![Coverage Status](https://coveralls.io/repos/github/keenlabs/keen-sdk-net/badge.svg?branch=jm_AppVeyorCI)](https://coveralls.io/github/keenlabs/keen-sdk-net?branch=jm_AppVeyorCI)
 
 Overview
 -----


### PR DESCRIPTION
Put in place some config to start building pushes/PRs with AppVeyor and capturing Code Coverage numbers, reporting them to Coveralls.io and updating badges in the readme file.

Eventually this should all be linked to the keenlabs GitHub org, but we can figure that out later once we've baked the whole process a bit more. Here are some examples of the test results, code coverage reporting in Coveralls, github checks, jobs running in AppVeyor, and updated badges:

![badges](https://user-images.githubusercontent.com/11385690/28497903-cfb2d80e-6f57-11e7-98a8-380935e434dc.png)
![code_coverage](https://user-images.githubusercontent.com/11385690/28497904-cfb36224-6f57-11e7-9b46-b04fa8be1d06.png)
![github_checks](https://user-images.githubusercontent.com/11385690/28497907-cfb6f72c-6f57-11e7-85d3-9a48b5fb5aba.png)
![multiple_jobs](https://user-images.githubusercontent.com/11385690/28497905-cfb559e4-6f57-11e7-92a9-466830ef5431.png)
![test_results](https://user-images.githubusercontent.com/11385690/28497906-cfb61f0a-6f57-11e7-8900-70af6c33033a.png)




