### PR TITLE
[WIP] Port event cache memory

### DIFF
--- a/Keen.NetStandard/EventCacheMemory.cs
+++ b/Keen.NetStandard/EventCacheMemory.cs
@@ -1,0 +1,47 @@
+﻿using Keen.NetStandard.EventCache;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Keen.NetStandard
+{
+    /// <summary>
+    /// <para>This is a simple memory-based cache provider. It has no cache-expiration policy.
+    /// To use, pass an instance of this class when constructing KeenClient</para>
+    /// <seealso cref="Keen.NetStandard.KeenClient"/>
+    /// </summary>
+    public class EventCacheMemory : IEventCache
+    {
+        private Queue<CachedEvent> events = new Queue<CachedEvent>();
+
+        public Task Add(CachedEvent e)
+        {
+            if (null == e)
+                throw new KeenException("Cached events may not be null");
+
+            return Task.Run(() =>
+            {
+                lock (events)
+                    events.Enqueue(e);
+            });
+        }
+
+        public Task Clear()
+        {
+            return Task.Run(() =>
+            {
+                lock (events)
+                    events.Clear();
+            });
+        }
+
+        public Task<CachedEvent> TryTake()
+        {
+            return Task.Run(() =>
+            {
+                lock (events)
+                    return events.Any() ? events.Dequeue() : null;
+            });
+        }
+    }
+}

--- a/Keen.NetStandard/KeenClient.cs
+++ b/Keen.NetStandard/KeenClient.cs
@@ -238,7 +238,7 @@ namespace Keen.NetStandard
                 throw ex.TryUnwrap();
             }
         }
-        /*
+        
         /// <summary>
         /// Insert multiple events in a single request.
         /// </summary>
@@ -257,6 +257,7 @@ namespace Keen.NetStandard
             }
         }
 
+        
         /// <summary>
         /// Add a collection of events to the specified collection. Assumes that
         /// objects in the collection have already been through AddEvent to receive
@@ -321,7 +322,7 @@ namespace Keen.NetStandard
                     throw new KeenBulkException("One or more events was rejected during the bulk add operation", errs);
                 // ReSharper restore PossibleMultipleEnumeration
             }
-        }*/
+        }
 
         /// <summary>
         /// Add a single event to the specified collection.

--- a/Keen.NetStandard/KeenClient.cs
+++ b/Keen.NetStandard/KeenClient.cs
@@ -321,7 +321,7 @@ namespace Keen.NetStandard
                     throw new KeenBulkException("One or more events was rejected during the bulk add operation", errs);
                 // ReSharper restore PossibleMultipleEnumeration
             }
-        }
+        }*/
 
         /// <summary>
         /// Add a single event to the specified collection.
@@ -348,7 +348,7 @@ namespace Keen.NetStandard
                 await EventCollection.AddEvent(collection, jEvent)
                     .ConfigureAwait(false);
         }
-
+        
         /// <summary>
         /// Convert a user-supplied object to a JObject that can be sent to the Keen.IO API.
         /// 
@@ -418,6 +418,7 @@ namespace Keen.NetStandard
             }
         }
 
+        /*
         /// <summary>
         /// Submit all events found in the event cache. If any events are rejected by the server,
         /// KeenCacheException will be thrown with a listing of the rejected events, each with

--- a/Keen.NetStandard/KeenClient.cs
+++ b/Keen.NetStandard/KeenClient.cs
@@ -419,7 +419,6 @@ namespace Keen.NetStandard
             }
         }
 
-        /*
         /// <summary>
         /// Submit all events found in the event cache. If any events are rejected by the server,
         /// KeenCacheException will be thrown with a listing of the rejected events, each with
@@ -487,6 +486,7 @@ namespace Keen.NetStandard
                 throw new KeenBulkException("One or more cached events could not be submitted", failedEvents);
         }
 
+        /*
         /// <summary>
         /// Retrieve a list of all the queries supported by the API.
         /// </summary>


### PR DESCRIPTION
@masojus It works...

Quick testing for the class, console displayed what was expected
![image](https://user-images.githubusercontent.com/12190565/28741995-92efd90a-73f1-11e7-8412-e0119912cace.png)

For the functions that require a cache...
![image](https://user-images.githubusercontent.com/12190565/28741998-a64cc03a-73f1-11e7-8ca9-77d45842e0e2.png)

![image](https://user-images.githubusercontent.com/12190565/28741999-adef4e20-73f1-11e7-9587-fe8321f8b622.png)

(In the above picture, I believe events get sent from the SendEventsAsync function because in a previous test I did not have that function and they did not show up on the upstream interface)

Pictures for documentation. Based on https://github.com/keenlabs/keen-sdk-net/pull/101

Look to:
close #62 
