### PR TITLE
Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: csharp
+
+# .NET Core version
+dotnet: 2.0.0-preview2-006497
+
+# Don't bother with mono since we're doing a .NET Core-based build
+mono: none
+
+# OS matrix
+os:
+  - linux
+  - osx
+
+# Ubuntu version for the linux build
+dist: trusty
+
+# The image to use for the osx build
+osx_image: xcode8.3
+
+# Build and run the Keen.NetStandard project and run its tests
+script: |
+  cd Keen.NetStandard.Test
+  dotnet test


### PR DESCRIPTION
This adds a simple .travis.yml file for building the Keen.NetStandard and Keen.NetStandard.Test assemblies, and then running tests on Linux and MacOS.