### PR TITLE
Project settings file tests, move to json format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,9 @@ $RECYCLE.BIN/
 
 TestResult.xml
 Keen.VisualState.xml
+
+# Visual Studio Code
+.vscode/
+
+# Visual Studio for Mac
+*.userprefs

--- a/Keen.NetStandard.Test/ProjectSettingsProviderTest.cs
+++ b/Keen.NetStandard.Test/ProjectSettingsProviderTest.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.IO;
 using NUnit.Framework;
-
+using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Keen.NetStandard.Tests
 {
@@ -93,6 +94,85 @@ namespace Keen.NetStandard.Tests
             finally
             {
                 File.Delete(fp);
+            }
+        }
+
+        [Test]
+        public void SettingsProviderFile_NoKey_Throws()
+        {
+            var fileName = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(fileName, JsonConvert.SerializeObject(
+                    new Dictionary<string, string>
+                    {
+                        [KeenConstants.KeenProjectId] = "projectId"
+                    }
+                ));
+
+                Assert.Throws<KeenException>(() => new ProjectSettingsProviderFile(fileName, isJsonFile: true));
+            }
+            finally
+            {
+                File.Delete(fileName);
+            }
+        }
+
+        [Test]
+        public void SettingsProviderFile_ValidMinimalConfig_Success()
+        {
+            var fileName = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(fileName, JsonConvert.SerializeObject(
+                    new Dictionary<string, string>
+                    {
+                        [KeenConstants.KeenProjectId] = "projectId",
+                        [KeenConstants.KeenReadKey] = "readKey"
+                    }
+                ));
+
+                Assert.DoesNotThrow(() => new ProjectSettingsProviderFile(fileName, isJsonFile: true));
+            }
+            finally
+            {
+                File.Delete(fileName);
+            }
+        }
+
+        [Test]
+        public void SettingsProviderFile_ConfigIsCorrect_Success()
+        {
+            var projectId = "projectId";
+            var readKey = "readKey";
+            var writeKey = "writeKey";
+            var masterKey = "masterKey";
+            var baseUrl = "baseUrl";
+
+            var fileName = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(fileName, JsonConvert.SerializeObject(
+                    new Dictionary<string, string>
+                    {
+                        [KeenConstants.KeenProjectId] = projectId,
+                        [KeenConstants.KeenReadKey] = readKey,
+                        [KeenConstants.KeenWriteKey] = writeKey,
+                        [KeenConstants.KeenMasterKey] = masterKey,
+                        [KeenConstants.KeenServerUrl] = baseUrl
+                    }
+                ));
+
+                var settings = new ProjectSettingsProviderFile(fileName, isJsonFile: true);
+                Assert.AreEqual(settings.ProjectId, projectId);
+                Assert.AreEqual(settings.ReadKey, readKey);
+                Assert.AreEqual(settings.WriteKey, writeKey);
+                Assert.AreEqual(settings.MasterKey, masterKey);
+                Assert.AreEqual(settings.KeenUrl, baseUrl);
+            }
+            finally
+            {
+                File.Delete(fileName);
             }
         }
     }

--- a/Keen.NetStandard.Test/ProjectSettingsProviderTest.cs
+++ b/Keen.NetStandard.Test/ProjectSettingsProviderTest.cs
@@ -70,7 +70,7 @@ namespace Keen.NetStandard.Tests
             var fp = Path.GetTempFileName();
             try 
             {
-                File.WriteAllText(fp, "X\nX");
+                File.WriteAllText(fp, "X");
 
                 Assert.Throws<KeenException>(() => new ProjectSettingsProviderFile(fp));
             }

--- a/Keen.NetStandard.Test/ProjectSettingsProviderTest.cs
+++ b/Keen.NetStandard.Test/ProjectSettingsProviderTest.cs
@@ -12,13 +12,13 @@ namespace Keen.NetStandard.Tests
         [Test]
         public void Settings_DefaultInputs_Success()
         {
-            Assert.DoesNotThrow(() => new ProjectSettingsProvider("X", null));
+            Assert.DoesNotThrow(() => new ProjectSettingsProvider("X", "Y"));
         }
 
         [Test]
-        public void Settings_AllNull_Success()
+        public void Settings_AllNull_Throws()
         {
-            Assert.DoesNotThrow(() => new ProjectSettingsProvider(null));
+            Assert.Throws<KeenException>(() => new ProjectSettingsProvider(null));
         }
 
         [Test]
@@ -29,8 +29,7 @@ namespace Keen.NetStandard.Tests
             Environment.SetEnvironmentVariable(KeenConstants.KeenWriteKey, null);
             Environment.SetEnvironmentVariable(KeenConstants.KeenReadKey, null);
 
-            var settings = new ProjectSettingsProviderEnv();
-            Assert.Throws<KeenException>(() => new KeenClient(settings));
+            Assert.Throws<KeenException>(() => new ProjectSettingsProviderEnv());
         }
 
         [Test]
@@ -41,8 +40,7 @@ namespace Keen.NetStandard.Tests
             Environment.SetEnvironmentVariable(KeenConstants.KeenWriteKey, "X");
             Environment.SetEnvironmentVariable(KeenConstants.KeenReadKey, "X");
 
-            var settings = new ProjectSettingsProviderEnv();
-            Assert.DoesNotThrow(() => new KeenClient(settings));
+            Assert.DoesNotThrow(() => new ProjectSettingsProviderEnv());
         }
 
         [Test]
@@ -66,38 +64,6 @@ namespace Keen.NetStandard.Tests
         }
 
         [Test]
-        public void SettingsProviderFile_InvalidFile_Throws()
-        {
-            var fp = Path.GetTempFileName();
-            try 
-            {
-                File.WriteAllText(fp, "X");
-
-                Assert.Throws<KeenException>(() => new ProjectSettingsProviderFile(fp));
-            }
-            finally
-            {
-                File.Delete(fp);
-            }
-        }
-
-        [Test]
-        public void SettingsProviderFile_ValidFile_Success()
-        {
-            var fp = Path.GetTempFileName();
-            try
-            {
-                File.WriteAllText(fp, "X\nX\nX\nX");
-
-                Assert.DoesNotThrow(() => new ProjectSettingsProviderFile(fp));
-            }
-            finally
-            {
-                File.Delete(fp);
-            }
-        }
-
-        [Test]
         public void SettingsProviderFile_NoKey_Throws()
         {
             var fileName = Path.GetTempFileName();
@@ -110,7 +76,7 @@ namespace Keen.NetStandard.Tests
                     }
                 ));
 
-                Assert.Throws<KeenException>(() => new ProjectSettingsProviderFile(fileName, isJsonFile: true));
+                Assert.Throws<KeenException>(() => new ProjectSettingsProviderFile(fileName));
             }
             finally
             {
@@ -132,7 +98,7 @@ namespace Keen.NetStandard.Tests
                     }
                 ));
 
-                Assert.DoesNotThrow(() => new ProjectSettingsProviderFile(fileName, isJsonFile: true));
+                Assert.DoesNotThrow(() => new ProjectSettingsProviderFile(fileName));
             }
             finally
             {
@@ -163,7 +129,7 @@ namespace Keen.NetStandard.Tests
                     }
                 ));
 
-                var settings = new ProjectSettingsProviderFile(fileName, isJsonFile: true);
+                var settings = new ProjectSettingsProviderFile(fileName);
                 Assert.AreEqual(settings.ProjectId, projectId);
                 Assert.AreEqual(settings.ReadKey, readKey);
                 Assert.AreEqual(settings.WriteKey, writeKey);

--- a/Keen.NetStandard.Test/ProjectSettingsProviderTest.cs
+++ b/Keen.NetStandard.Test/ProjectSettingsProviderTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using NUnit.Framework;
 
 
@@ -61,6 +62,38 @@ namespace Keen.NetStandard.Tests
             Assert.AreEqual(settings.MasterKey, masterKey, "Master key wasn't properly set");
             Assert.AreEqual(settings.WriteKey, writeKey, "Write key wasn't properly set");
             Assert.AreEqual(settings.ReadKey, readKey, "Read key wasn't properly set");
+        }
+
+        [Test]
+        public void SettingsProviderFile_InvalidFile_Throws()
+        {
+            var fp = Path.GetTempFileName();
+            try 
+            {
+                File.WriteAllText(fp, "X\nX");
+
+                Assert.Throws<KeenException>(() => new ProjectSettingsProviderFile(fp));
+            }
+            finally
+            {
+                File.Delete(fp);
+            }
+        }
+
+        [Test]
+        public void SettingsProviderFile_ValidFile_Success()
+        {
+            var fp = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(fp, "X\nX\nX\nX");
+
+                Assert.DoesNotThrow(() => new ProjectSettingsProviderFile(fp));
+            }
+            finally
+            {
+                File.Delete(fp);
+            }
         }
     }
 }

--- a/Keen.NetStandard/ProjectSettingsProvider.cs
+++ b/Keen.NetStandard/ProjectSettingsProvider.cs
@@ -40,8 +40,40 @@ namespace Keen.NetStandard
         /// <param name="writeKey">Write API key, required for inserting events</param>
         /// <param name="readKey">Read API key, required for performing queries</param>
         /// <param name="keenUrl">Base Keen.IO service URL</param>
-        public ProjectSettingsProvider(string projectId, string masterKey = "", string writeKey = "", string readKey = "", string keenUrl = null)
+        public ProjectSettingsProvider(
+        	string projectId,
+        	string masterKey = null,
+        	string writeKey = null,
+        	string readKey = null,
+        	string keenUrl = null)
         {
+            Initialize(projectId, masterKey, writeKey, readKey, keenUrl);
+        }
+
+        /// <summary>
+        /// Protected constructor to allow base classes to share initialization code more conveniently than by having to pass parameters through a constructor
+        /// </summary>
+        protected ProjectSettingsProvider() {}
+
+        protected void Initialize(
+        	string projectId,
+        	string masterKey,
+        	string writeKey,
+        	string readKey,
+        	string keenUrl)
+        {
+            if (string.IsNullOrWhiteSpace(projectId))
+            {
+                throw new KeenException($"A project id must be provided.");
+            }
+
+            if (string.IsNullOrWhiteSpace(masterKey) && 
+                string.IsNullOrWhiteSpace(writeKey) &&
+                string.IsNullOrWhiteSpace(readKey))
+            {
+                throw new KeenException($"A value for a read key, write key, or master key must be provided.");
+            }
+
             KeenUrl = keenUrl ?? KeenConstants.ServerAddress + "/" + KeenConstants.ApiVersion + "/";
             ProjectId = projectId;
             MasterKey = masterKey;

--- a/Keen.NetStandard/ProjectSettingsProviderEnv.cs
+++ b/Keen.NetStandard/ProjectSettingsProviderEnv.cs
@@ -18,11 +18,11 @@ namespace Keen.NetStandard
         /// <para>Keen.IO API url should be in variable KEEN_SERVER_URL</para>
         /// </summary>
         public ProjectSettingsProviderEnv()
-            : base(Environment.GetEnvironmentVariable(KeenConstants.KeenProjectId) ?? "",
-                    masterKey: Environment.GetEnvironmentVariable(KeenConstants.KeenMasterKey) ?? "",
-                    writeKey: Environment.GetEnvironmentVariable(KeenConstants.KeenWriteKey) ?? "",
-                    readKey: Environment.GetEnvironmentVariable(KeenConstants.KeenReadKey) ?? "",
-                    keenUrl: Environment.GetEnvironmentVariable(KeenConstants.KeenServerUrl) ?? KeenConstants.ServerAddress + "/" + KeenConstants.ApiVersion + "/")
+            : base(Environment.GetEnvironmentVariable(KeenConstants.KeenProjectId) ?? null,
+                   masterKey: Environment.GetEnvironmentVariable(KeenConstants.KeenMasterKey) ?? null,
+                   writeKey: Environment.GetEnvironmentVariable(KeenConstants.KeenWriteKey) ?? null,
+                   readKey: Environment.GetEnvironmentVariable(KeenConstants.KeenReadKey) ?? null,
+                   keenUrl: Environment.GetEnvironmentVariable(KeenConstants.KeenServerUrl) ?? null)
         {
 
         }

--- a/Keen.NetStandard/ProjectSettingsProviderFile.cs
+++ b/Keen.NetStandard/ProjectSettingsProviderFile.cs
@@ -75,7 +75,13 @@ namespace Keen.NetStandard
             else
             {
                 // TODO : Master key maybe should be de-emphasized and not be first.
-                var values = File.ReadLines(filePath).ToList();                
+                var values = File.ReadLines(filePath).ToList();
+
+                // TODO : This file format is pretty silly. We should get rid of it.
+                if (values.Count < 2)
+                {
+                    throw new KeenException("Expected file format is a list of the project id, master key, write key, read key, and api base authority separated by newlines. At least a project id and master key need to be provided."); // </cringe>
+                }
 
                 _fileProjectId = values.ElementAtOrDefault(0);
                 _fileMasterKey = values.ElementAtOrDefault(1);

--- a/Keen.NetStandard/ProjectSettingsProviderFile.cs
+++ b/Keen.NetStandard/ProjectSettingsProviderFile.cs
@@ -9,100 +9,35 @@ namespace Keen.NetStandard
     /// </summary>
     public class ProjectSettingsProviderFile : ProjectSettingsProvider
     {
-        private static string _fileKeenUrl { get; set; }
-        private static string _fileProjectId { get; set; }
-        private static string _fileMasterKey { get; set; }
-        private static string _fileWriteKey { get; set; }
-        private static string _fileReadKey { get; set; }
-
         /// <summary>
-        /// <para>Reads the project settings from a text file.</para>
-        /// <para>Each setting takes one line, in the order: Project ID, Master Key, Write Key,
-        /// Read Key, Keen.IO API url. Unused values should be represented
-        /// with a blank line.</para>
+        /// <para>Reads project settings from a json formatted file with a root object containing the below keys.</para>
+        /// <para>KEEN_PROJECT_ID is required, along with at least one access key.</para>
+        /// <para>KEEN_PROJECT_ID key should contain the Project Id. Required.</para>
+        /// <para>KEEN_MASTER_KEY key should contain the Master Key. Optional, and highly discouraged unless using APIs that require a master key.</para>
+        /// <para>KEEN_WRITE_KEY key should contain the Write Key. Optional, though at least one access key is required.</para>
+        /// <para>KEEN_READ_KEY key should contain the ReadKey. Optional, though at least one access key is required.</para>
+        /// <para>KEEN_SERVER_URL key should contain the Keen.IO API url. Optional.</para>
         /// </summary>
         /// <param name="filePath">The path to the file</param>
         public ProjectSettingsProviderFile(string filePath)
-            : base(SetSettingsFromFile(filePath, false),
-                    masterKey: _fileMasterKey,
-                    writeKey: _fileWriteKey,
-                    readKey: _fileReadKey,
-                    keenUrl: _fileKeenUrl)
         {
-
-        }
-
-        /// <summary>
-        /// <para>If the isJsonFile parameter is set to true, then the key value pairs should be in
-        /// a JSON object.</para>
-        /// <para>KEEN_PROJECT_ID key should contain the Project Id</para>
-        /// <para>KEEN_MASTER_KEY key should contain the Master Key</para>
-        /// <para>KEEN_WRITE_KEY key should contain the Write Key</para>
-        /// <para>KEEN_READ_KEY key should contain the ReadKey</para>
-        /// <para>KEEN_SERVER_URL key should contain the Keen.IO API url</para>
-        /// </summary>
-        /// <param name="filePath">The path to the file</param>
-        /// <param name="isJsonFile">Indicates whether the file should be parsed as JSON</param>
-        public ProjectSettingsProviderFile(string filePath, bool isJsonFile = false)
-            : base(SetSettingsFromFile(filePath, isJsonFile),
-            masterKey: _fileMasterKey,
-            writeKey: _fileWriteKey,
-            readKey: _fileReadKey,
-            keenUrl: _fileKeenUrl)
-        {
-
-        }
-
-        /// <summary>
-        /// Maps the file contents onto the private variables to then be used by the constructor
-        /// </summary>
-        /// <param name="filePath">The path to the file</param>
-        /// <param name="isJsonFile">Indicates whether the file should be parsed as JSON</param>
-        /// <returns>The ProjectId</returns>
-        private static string SetSettingsFromFile(string filePath, bool isJsonFile = false)
-        {
-            if (isJsonFile)
+            try
             {
                 // http://www.newtonsoft.com/json/help/html/ReadJson.htm
                 JObject jsonProjectSettings = JObject.Parse(File.ReadAllText(filePath));
-
-                _fileKeenUrl = (string)jsonProjectSettings[KeenConstants.KeenServerUrl];
-                _fileProjectId = (string)jsonProjectSettings[KeenConstants.KeenProjectId];
-                _fileMasterKey = (string)jsonProjectSettings[KeenConstants.KeenMasterKey];
-                _fileWriteKey = (string)jsonProjectSettings[KeenConstants.KeenWriteKey];
-                _fileReadKey = (string)jsonProjectSettings[KeenConstants.KeenReadKey];
-
-                if (string.IsNullOrWhiteSpace(_fileProjectId))
-                {
-                    throw new KeenException($"A value for the key {KeenConstants.KeenProjectId} must be provided.");
-                }
-
-                if (string.IsNullOrWhiteSpace(_fileMasterKey) && 
-                    string.IsNullOrWhiteSpace(_fileWriteKey) &&
-                    string.IsNullOrWhiteSpace(_fileReadKey))
-                {
-                    throw new KeenException($"A value for one of {KeenConstants.KeenReadKey}, {KeenConstants.KeenWriteKey}, or {KeenConstants.KeenMasterKey} must be provided.");
-                }
+                
+                Initialize(
+	                (string)jsonProjectSettings[KeenConstants.KeenProjectId],
+	                (string)jsonProjectSettings[KeenConstants.KeenMasterKey],
+	                (string)jsonProjectSettings[KeenConstants.KeenWriteKey],
+	                (string)jsonProjectSettings[KeenConstants.KeenReadKey],
+	                (string)jsonProjectSettings[KeenConstants.KeenServerUrl]);
             }
-            else
+            catch (Newtonsoft.Json.JsonReaderException ex)
             {
-                // TODO : Master key maybe should be de-emphasized and not be first.
-                var values = File.ReadLines(filePath).ToList();
-
-                // TODO : This file format is pretty silly. We should get rid of it.
-                if (values.Count < 2)
-                {
-                    throw new KeenException("Expected file format is a list of the project id, master key, write key, read key, and api base authority separated by newlines. At least a project id and master key need to be provided."); // </cringe>
-                }
-
-                _fileProjectId = values.ElementAtOrDefault(0);
-                _fileMasterKey = values.ElementAtOrDefault(1);
-                _fileWriteKey = values.ElementAtOrDefault(2);
-                _fileReadKey = values.ElementAtOrDefault(3);
-                _fileKeenUrl = values.ElementAtOrDefault(4);
+                throw new KeenException("Failed to read configuration file.",
+                                        ex);
             }
-
-            return _fileProjectId;
         }
     }
 }

--- a/Keen.NetStandard/ProjectSettingsProviderFile.cs
+++ b/Keen.NetStandard/ProjectSettingsProviderFile.cs
@@ -71,6 +71,18 @@ namespace Keen.NetStandard
                 _fileMasterKey = (string)jsonProjectSettings[KeenConstants.KeenMasterKey];
                 _fileWriteKey = (string)jsonProjectSettings[KeenConstants.KeenWriteKey];
                 _fileReadKey = (string)jsonProjectSettings[KeenConstants.KeenReadKey];
+
+                if (string.IsNullOrWhiteSpace(_fileProjectId))
+                {
+                    throw new KeenException($"A value for the key {KeenConstants.KeenProjectId} must be provided.");
+                }
+
+                if (string.IsNullOrWhiteSpace(_fileMasterKey) && 
+                    string.IsNullOrWhiteSpace(_fileWriteKey) &&
+                    string.IsNullOrWhiteSpace(_fileReadKey))
+                {
+                    throw new KeenException($"A value for one of {KeenConstants.KeenReadKey}, {KeenConstants.KeenWriteKey}, or {KeenConstants.KeenMasterKey} must be provided.");
+                }
             }
             else
             {


### PR DESCRIPTION
This moves to only support a json-formatted config file, which @Donistivanov first implemented and was an awesome idea.

In the process, ported the old tests, and then removed them. Added new tests for reading from json files.

Also consolidated a bit of duplicated code and simplified how `ProjectSettingsProviderFile` did initialization.

Note that this changes behavior of the `ProjectSettingsProvider` constructor, as it will now throw if you don't provide a project id. The members are protected, and we'd only throw if you tried to new up a `KeenClient` with that invalid `ProjectSettingsProvider`. I think it's better to disallow creating a provider that has invalid state.

Fixes #109 