### PR TITLE
Add a bunch of integration tests for Metric, Funnel, and MultiAnalysis

### DIFF
--- a/Keen.NET.Test/Keen.NET.Test.csproj
+++ b/Keen.NET.Test/Keen.NET.Test.csproj
@@ -85,6 +85,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Keen.NET.Test/Keen.NET.Test.csproj
+++ b/Keen.NET.Test/Keen.NET.Test.csproj
@@ -115,6 +115,7 @@
     <Compile Include="ScopedKeyTest.cs" />
     <Compile Include="DelegatingHandlerMock.cs" />
     <Compile Include="TestKeenHttpClientProvider.cs" />
+    <Compile Include="TimeframeConverterTest.cs" />
     <Compile Include="UrlToMessageHandler.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Keen.NET.Test/QueryTests_Integration.cs
+++ b/Keen.NET.Test/QueryTests_Integration.cs
@@ -166,5 +166,132 @@ namespace Keen.Net.Test
                 Assert.That(actualQueries.Contains(expectedQuery));
             }
         }
+
+        [Test]
+        public async Task Query_SimpleCount_Success()
+        {
+            string expectedResult = "10";
+            string collection = "myEvents";
+            QueryType analysis = QueryType.Count();
+
+            var expectedResponse = new Dictionary<string, string>()
+            {
+                { "result", expectedResult},
+            };
+
+            FuncHandler handler = new FuncHandler()
+            {
+                ProduceResultAsync = (request, ct) =>
+                {
+                    var expectedUri = new Uri($"{HttpTests.GetUriForResource(SettingsEnv, KeenConstants.QueriesResource)}/" +
+                                              $"{analysis}?event_collection={collection}");
+                    Assert.AreEqual(expectedUri, request.RequestUri);
+                    return HttpTests.CreateJsonStringResponseAsync(expectedResponse);
+                }
+            };
+
+            var client = new KeenClient(SettingsEnv, new TestKeenHttpClientProvider()
+            {
+                ProvideKeenHttpClient =
+                    (url) => KeenHttpClientFactory.Create(url,
+                                                          new HttpClientCache(),
+                                                          null,
+                                                          new DelegatingHandlerMock(handler))
+            });
+
+            var actualResult = await client.Queries.Metric(analysis, collection, null);
+
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [Test]
+        public async Task Query_SimpleAverage_Success()
+        {
+            string expectedResult = "10";
+            string collection = "myEvents";
+            QueryType analysis = QueryType.Average();
+            string targetProperty = "someProperty";
+
+            var expectedResponse = new Dictionary<string, string>()
+            {
+                { "result", expectedResult},
+            };
+
+            FuncHandler handler = new FuncHandler()
+            {
+                ProduceResultAsync = (request, ct) =>
+                {
+                    var expectedUri = new Uri($"{HttpTests.GetUriForResource(SettingsEnv, KeenConstants.QueriesResource)}/" +
+                                              $"{analysis}?event_collection={collection}&target_property={targetProperty}");
+                    Assert.AreEqual(expectedUri, request.RequestUri);
+                    return HttpTests.CreateJsonStringResponseAsync(expectedResponse);
+                }
+            };
+
+            var client = new KeenClient(SettingsEnv, new TestKeenHttpClientProvider()
+            {
+                ProvideKeenHttpClient =
+                    (url) => KeenHttpClientFactory.Create(url,
+                                                          new HttpClientCache(),
+                                                          null,
+                                                          new DelegatingHandlerMock(handler))
+            });
+
+            var actualResult = await client.Queries.Metric(analysis, collection, targetProperty);
+
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [Test]
+        public async Task Query_SimpleCountGroupBy_Success()
+        {
+            var expectedResults = new List<string>() { "10", "20" };
+            var expectedGroups = new List<string>() { "group1", "group2" };
+            string collection = "myEvents";
+            QueryType analysis = QueryType.Average();
+            string targetProperty = "someProperty";
+            string groupBy = "someGroupProperty";
+            var expectedGroupResults = expectedResults.Zip(
+                expectedGroups,
+                (result, group) => new Dictionary<string, string>()
+                {
+                    { groupBy, group },
+                    { "result", result }
+                });
+
+            var expectedResponse = new
+            {
+                result = expectedGroupResults
+            };
+
+            FuncHandler handler = new FuncHandler()
+            {
+                ProduceResultAsync = (request, ct) =>
+                {
+                    var expectedUri = new Uri($"{HttpTests.GetUriForResource(SettingsEnv, KeenConstants.QueriesResource)}/" +
+                                              $"{analysis}?event_collection={collection}&target_property={targetProperty}&group_by={groupBy}");
+                    Assert.AreEqual(expectedUri, request.RequestUri);
+                    return HttpTests.CreateJsonStringResponseAsync(expectedResponse);
+                }
+            };
+
+            var client = new KeenClient(SettingsEnv, new TestKeenHttpClientProvider()
+            {
+                ProvideKeenHttpClient =
+                    (url) => KeenHttpClientFactory.Create(url,
+                                                          new HttpClientCache(),
+                                                          null,
+                                                          new DelegatingHandlerMock(handler))
+            });
+
+            var actualGroupResults = await client.Queries.Metric(analysis, collection, targetProperty, groupBy);
+
+            Assert.AreEqual(expectedGroupResults.Count(), actualGroupResults.Count());
+            foreach (var actualGroupResult in actualGroupResults)
+            {
+                var expectedGroupResult = expectedGroupResults.Where((result) => result[groupBy] == actualGroupResult.Group).First();
+                Assert.AreEqual(expectedGroupResult["result"], actualGroupResult.Value);
+            }
+        }
     }
 }

--- a/Keen.NET.Test/QueryTests_Integration.cs
+++ b/Keen.NET.Test/QueryTests_Integration.cs
@@ -3,6 +3,7 @@ using Keen.Core.Query;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 
@@ -118,6 +119,52 @@ namespace Keen.Net.Test
 
             Assert.IsNotNull(count);
             Assert.AreEqual("2", count);
-        } 
+        }
+
+        [Test]
+        public async Task Query_AvailableQueries_Success()
+        {
+            var queriesResource = HttpTests.GetUriForResource(SettingsEnv, KeenConstants.QueriesResource);
+
+            var expectedQueries = new Dictionary<string, string>()
+            {
+                { "select_unique_url", $"{queriesResource.AbsolutePath}/select_unique"},
+                { "minimum", $"{queriesResource.AbsolutePath}/minimum" },
+                { "extraction_url", $"{queriesResource.AbsolutePath}/extraction" },
+                { "percentile", $"{queriesResource.AbsolutePath}/percentile" },
+                { "funnel_url", $"{queriesResource.AbsolutePath}/funnel" },
+                { "average", $"{queriesResource.AbsolutePath}/average" },
+                { "median", $"{queriesResource.AbsolutePath}/median" },
+                { "maximum", $"{queriesResource.AbsolutePath}/maximum" },
+                { "count_url", $"{queriesResource.AbsolutePath}/count" },
+                { "count_unique_url", $"{queriesResource.AbsolutePath}/count_unique" },
+                { "sum", $"{queriesResource.AbsolutePath}/sum"}
+            };
+
+            FuncHandler handler = new FuncHandler()
+            {
+                ProduceResultAsync = (request, ct) =>
+                {
+                    return HttpTests.CreateJsonStringResponseAsync(expectedQueries);
+                }
+            };
+
+            var client = new KeenClient(SettingsEnv, new TestKeenHttpClientProvider()
+            {
+                ProvideKeenHttpClient =
+                    (url) => KeenHttpClientFactory.Create(url,
+                                                          new HttpClientCache(),
+                                                          null,
+                                                          new DelegatingHandlerMock(handler))
+            });
+
+            var actualQueries = await client.GetQueries();
+
+            Assert.AreEqual(expectedQueries.Count, actualQueries.Count());
+            foreach (var expectedQuery in expectedQueries)
+            {
+                Assert.That(actualQueries.Contains(expectedQuery));
+            }
+        }
     }
 }

--- a/Keen.NET.Test/TimeframeConverterTest.cs
+++ b/Keen.NET.Test/TimeframeConverterTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using Newtonsoft.Json;
+using Keen.Core.Query;
+
+namespace Keen.NetStandard.Test
+{
+    [TestFixture]
+    class TimeframeConverterTest
+    {
+        [Test]
+        public void Test_TimeframeConverter_Serializes()
+        {
+            var timeframeString = "this_4_hours";
+            var timeframe = QueryRelativeTimeframe.Create(timeframeString);
+
+            string json = JsonConvert.SerializeObject(timeframe);
+
+            Assert.AreEqual($"\"{timeframeString}\"", json);
+        }
+
+        [Test]
+        public void Test_TimeframeConverter_Deserializes()
+        {
+            var timeframeString = "this_4_hours";
+            var timeframeJson = $"\"{timeframeString}\"";
+
+            var timeframe = JsonConvert.DeserializeObject<QueryRelativeTimeframe>(timeframeJson);
+
+            Assert.AreEqual(timeframeString, timeframe.ToString());
+        }
+    }
+}

--- a/Keen.NetStandard.Test/QueryTests_Integration.cs
+++ b/Keen.NetStandard.Test/QueryTests_Integration.cs
@@ -253,7 +253,10 @@ namespace Keen.Core.Test
                 var multiAnalysisParameters = GetMultiAnalysisParameters();
 
                 var jObjects = multiAnalysisParameters.Select(x =>
-                    new JProperty(x.Label, JObject.FromObject(new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
+                    new JProperty(x.Label, JObject.FromObject(
+                        string.IsNullOrEmpty(x.TargetProperty) ?
+                            (object)new { analysis_type = x.Analysis } :
+                            new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
 
                 var analysesJson = JsonConvert.SerializeObject(
                     new JObject(jObjects),
@@ -877,7 +880,8 @@ namespace Keen.Core.Test
                     new QueryParameters(),
                     new QueryParameters()
                     {
-                        Analysis = QueryType.Average()
+                        Analysis = QueryType.Average(),
+                        TargetProperty = "targetProperty"
                     }
                 }
             };

--- a/Keen.NetStandard.Test/QueryTests_Integration.cs
+++ b/Keen.NetStandard.Test/QueryTests_Integration.cs
@@ -165,5 +165,80 @@ namespace Keen.Core.Test
                 Assert.That(actualQueries.Contains(expectedQuery));
             }
         }
+
+        [Test]
+        public async Task Query_SimpleCount_Success()
+        {
+            string expectedResult = "10";
+            string collection = "myEvents";
+            QueryType analysis = QueryType.Count();
+
+            var expectedResponse = new Dictionary<string, string>()
+            {
+                { "result", expectedResult},
+            };
+
+            FuncHandler handler = new FuncHandler()
+            {
+                ProduceResultAsync = (request, ct) =>
+                {
+                    var expectedUri = new Uri($"{HttpTests.GetUriForResource(SettingsEnv, KeenConstants.QueriesResource)}/" +
+                                              $"{analysis}?event_collection={collection}");
+                    Assert.AreEqual(expectedUri, request.RequestUri);
+                    return HttpTests.CreateJsonStringResponseAsync(expectedResponse);
+                }
+            };
+
+            var client = new KeenClient(SettingsEnv, new TestKeenHttpClientProvider()
+            {
+                ProvideKeenHttpClient =
+                    (url) => KeenHttpClientFactory.Create(url,
+                                                          new HttpClientCache(),
+                                                          null,
+                                                          new DelegatingHandlerMock(handler))
+            });
+
+            var actualResult = await client.Queries.Metric(analysis, collection, null);
+
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [Test]
+        public async Task Query_SimpleAverage_Success()
+        {
+            string expectedResult = "10";
+            string collection = "myEvents";
+            QueryType analysis = QueryType.Average();
+            string targetProperty = "someProperty";
+
+            var expectedResponse = new Dictionary<string, string>()
+            {
+                { "result", expectedResult},
+            };
+
+            FuncHandler handler = new FuncHandler()
+            {
+                ProduceResultAsync = (request, ct) =>
+                {
+                    var expectedUri = new Uri($"{HttpTests.GetUriForResource(SettingsEnv, KeenConstants.QueriesResource)}/" +
+                                              $"{analysis}?event_collection={collection}&target_property={targetProperty}");
+                    Assert.AreEqual(expectedUri, request.RequestUri);
+                    return HttpTests.CreateJsonStringResponseAsync(expectedResponse);
+                }
+            };
+
+            var client = new KeenClient(SettingsEnv, new TestKeenHttpClientProvider()
+            {
+                ProvideKeenHttpClient =
+                    (url) => KeenHttpClientFactory.Create(url,
+                                                          new HttpClientCache(),
+                                                          null,
+                                                          new DelegatingHandlerMock(handler))
+            });
+
+            var actualResult = await client.Queries.Metric(analysis, collection, targetProperty);
+
+            Assert.AreEqual(expectedResult, actualResult);
+        }
     }
 }

--- a/Keen.NetStandard.Test/QueryTests_Integration.cs
+++ b/Keen.NetStandard.Test/QueryTests_Integration.cs
@@ -240,5 +240,57 @@ namespace Keen.Core.Test
 
             Assert.AreEqual(expectedResult, actualResult);
         }
+
+        [Test]
+        public async Task Query_SimpleCountGroupBy_Success()
+        {
+            var expectedResults = new List<string>() { "10", "20" };
+            var expectedGroups = new List<string>() { "group1", "group2" };
+            string collection = "myEvents";
+            QueryType analysis = QueryType.Average();
+            string targetProperty = "someProperty";
+            string groupBy = "someGroupProperty";
+            var expectedGroupResults = expectedResults.Zip(
+                expectedGroups,
+                (result, group) => new Dictionary<string, string>()
+                {
+                    { groupBy, group },
+                    { "result", result }
+                });
+
+            var expectedResponse = new
+            {
+                result = expectedGroupResults
+            };
+
+            FuncHandler handler = new FuncHandler()
+            {
+                ProduceResultAsync = (request, ct) =>
+                {
+                    var expectedUri = new Uri($"{HttpTests.GetUriForResource(SettingsEnv, KeenConstants.QueriesResource)}/" +
+                                              $"{analysis}?event_collection={collection}&target_property={targetProperty}&group_by={groupBy}");
+                    Assert.AreEqual(expectedUri, request.RequestUri);
+                    return HttpTests.CreateJsonStringResponseAsync(expectedResponse);
+                }
+            };
+
+            var client = new KeenClient(SettingsEnv, new TestKeenHttpClientProvider()
+            {
+                ProvideKeenHttpClient =
+                    (url) => KeenHttpClientFactory.Create(url,
+                                                          new HttpClientCache(),
+                                                          null,
+                                                          new DelegatingHandlerMock(handler))
+            });
+
+            var actualGroupResults = await client.Queries.Metric(analysis, collection, targetProperty, groupBy);
+
+            Assert.AreEqual(expectedGroupResults.Count(), actualGroupResults.Count());
+            foreach (var actualGroupResult in actualGroupResults)
+            {
+                var expectedGroupResult = expectedGroupResults.Where((result) => result[groupBy] == actualGroupResult.Group).First();
+                Assert.AreEqual(expectedGroupResult["result"], actualGroupResult.Value);
+            }
+        }
     }
 }

--- a/Keen.NetStandard.Test/QueryTests_Integration.cs
+++ b/Keen.NetStandard.Test/QueryTests_Integration.cs
@@ -909,5 +909,58 @@ namespace Keen.Core.Test
             }
         }
 
+        [Test]
+        public async Task Query_SimpleMultiAnalysisGroupBy_Success()
+        {
+            var queryParameters = new MultiAnalysisParameters()
+            {
+                Labels = new string[]
+                {
+                    "first analysis",
+                    "second analysis"
+                },
+                Analyses = new QueryParameters[]
+                {
+                    new QueryParameters(),
+                    new QueryParameters()
+                    {
+                        Analysis = QueryType.Average(),
+                        TargetProperty = "targetProperty"
+                    }
+                },
+                GroupBy = "groupByProperty"
+            };
+
+            string responseJson = $"{{\"result\":[" +
+                $"{{\"{queryParameters.GroupBy}\":\"group1\",\"{queryParameters.Labels[0]}\":12345,\"{queryParameters.Labels[1]}\":54321}}," +
+                $"{{\"{queryParameters.GroupBy}\":\"group2\",\"{queryParameters.Labels[0]}\":67890,\"{queryParameters.Labels[1]}\":9876}}" +
+                $"]}}";
+
+            var expectedResponse = JObject.Parse(responseJson);
+
+            var client = CreateQueryTestKeenClient(queryParameters, expectedResponse);
+
+            var actualResults = await client.Queries.MultiAnalysis(
+                queryParameters.EventCollection,
+                queryParameters.GetMultiAnalysisParameters(),
+                null,
+                null,
+                queryParameters.GroupBy,
+                null);
+
+            var expectedResults = expectedResponse["result"];
+
+            Assert.AreEqual(expectedResults.Count(), actualResults.Count());
+            foreach (var group in new string[] { "group1", "group2" })
+            {
+                var actualGroupResult = actualResults.Where((result) => result.Group == group).First();
+                var expectedGroupResult = expectedResults.Where((result) => result[queryParameters.GroupBy].Value<string>() == group).First();
+                foreach (var label in queryParameters.Labels)
+                {
+                    // Validate the result is correct
+                    Assert.AreEqual(expectedGroupResult[label].Value<int>(), int.Parse(actualGroupResult.Value[label]));
+                }
+            }
+        }
     }
 }

--- a/Keen.NetStandard.Test/TimeframeConverterTest.cs
+++ b/Keen.NetStandard.Test/TimeframeConverterTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using Newtonsoft.Json;
+using Keen.Core.Query;
+
+namespace Keen.NetStandard.Test
+{
+    [TestFixture]
+    class TimeframeConverterTest
+    {
+        [Test]
+        public void Test_TimeframeConverter_Serializes()
+        {
+            var timeframeString = "this_4_hours";
+            var timeframe = QueryRelativeTimeframe.Create(timeframeString);
+
+            string json = JsonConvert.SerializeObject(timeframe);
+
+            Assert.AreEqual($"\"{timeframeString}\"", json);
+        }
+
+        [Test]
+        public void Test_TimeframeConverter_Deserializes()
+        {
+            var timeframeString = "this_4_hours";
+            var timeframeJson = $"\"{timeframeString}\"";
+
+            var timeframe = JsonConvert.DeserializeObject<QueryRelativeTimeframe>(timeframeJson);
+
+            Assert.AreEqual(timeframeString, timeframe.ToString());
+        }
+    }
+}

--- a/Keen.NetStandard/Query/FunnelResultStep.cs
+++ b/Keen.NetStandard/Query/FunnelResultStep.cs
@@ -30,5 +30,33 @@ namespace Keen.Core.Query
 
         [JsonProperty(PropertyName = "inverted")]
         public bool Inverted { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var step = obj as FunnelResultStep;
+            return step != null &&
+                   WithActors == step.WithActors &&
+                   ActorProperty == step.ActorProperty &&
+                   EqualityComparer<IEnumerable<QueryFilter>>.Default.Equals(Filters, step.Filters) &&
+                   EqualityComparer<IQueryTimeframe>.Default.Equals(Timeframe, step.Timeframe) &&
+                   TimeZone == step.TimeZone &&
+                   EventCollection == step.EventCollection &&
+                   Optional == step.Optional &&
+                   Inverted == step.Inverted;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 1007130157;
+            hashCode = hashCode * -1521134295 + WithActors.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ActorProperty);
+            hashCode = hashCode * -1521134295 + EqualityComparer<IEnumerable<QueryFilter>>.Default.GetHashCode(Filters);
+            hashCode = hashCode * -1521134295 + EqualityComparer<IQueryTimeframe>.Default.GetHashCode(Timeframe);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(TimeZone);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventCollection);
+            hashCode = hashCode * -1521134295 + Optional.GetHashCode();
+            hashCode = hashCode * -1521134295 + Inverted.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Keen.NetStandard/Query/MultiAnalysisParam.cs
+++ b/Keen.NetStandard/Query/MultiAnalysisParam.cs
@@ -7,8 +7,8 @@ namespace Keen.Core.Query
         {
             private readonly string _value;
             public readonly string TargetProperty;
-            private Metric(string value) { _value = value; }
-            private Metric(string value, string targetProperty) { _value = value; TargetProperty = targetProperty;  }
+            internal Metric(string value) { _value = value; }
+            internal Metric(string value, string targetProperty) { _value = value; TargetProperty = targetProperty;  }
             public override string ToString() { return _value; }
             public static implicit operator string(Metric value) { return value.ToString(); }
 

--- a/Keen.NetStandard/Query/Queries.cs
+++ b/Keen.NetStandard/Query/Queries.cs
@@ -314,9 +314,16 @@ namespace Keen.Core.Query
 
         public async Task<IDictionary<string, string>> MultiAnalysis(string collection, IEnumerable<MultiAnalysisParam> analysisParams, IQueryTimeframe timeframe = null, IEnumerable<QueryFilter> filters = null, string timezone = "")
         {
-            var jObs = analysisParams.Select(x => 
-                new JProperty( x.Label, JObject.FromObject( new {analysis_type = x.Analysis, target_property = x.TargetProperty })));
-            var parmsJson = JsonConvert.SerializeObject(new JObject(jObs), Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+            var jObs = analysisParams.Select(x =>
+                new JProperty(x.Label, JObject.FromObject(
+                    string.IsNullOrEmpty(x.TargetProperty) ?
+                        (object)new { analysis_type = x.Analysis } :
+                        new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
+
+            var parmsJson = JsonConvert.SerializeObject(
+                new JObject(jObs),
+                Formatting.None,
+                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
 
             var parms = new Dictionary<string, string>();
             parms.Add(KeenConstants.QueryParmEventCollection, collection);

--- a/Keen.NetStandard/Query/Queries.cs
+++ b/Keen.NetStandard/Query/Queries.cs
@@ -312,7 +312,7 @@ namespace Keen.Core.Query
             return o;
         }
 
-        public async Task<IDictionary<string, string>> MultiAnalysis(string collection, IEnumerable<MultiAnalysisParam> analysisParams, IQueryTimeframe timeframe = null, IEnumerable<QueryFilter> filters = null, string timezone = "")
+        string SerializeMultiAnalysisQueryParameter(IEnumerable<MultiAnalysisParam> analysisParams)
         {
             var jObs = analysisParams.Select(x =>
                 new JProperty(x.Label, JObject.FromObject(
@@ -320,17 +320,20 @@ namespace Keen.Core.Query
                         (object)new { analysis_type = x.Analysis } :
                         new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
 
-            var parmsJson = JsonConvert.SerializeObject(
+            return JsonConvert.SerializeObject(
                 new JObject(jObs),
                 Formatting.None,
                 new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+        }
 
+        public async Task<IDictionary<string, string>> MultiAnalysis(string collection, IEnumerable<MultiAnalysisParam> analysisParams, IQueryTimeframe timeframe = null, IEnumerable<QueryFilter> filters = null, string timezone = "")
+        {
             var parms = new Dictionary<string, string>();
             parms.Add(KeenConstants.QueryParmEventCollection, collection);
             parms.Add(KeenConstants.QueryParmTimeframe, timeframe.ToSafeString());
             parms.Add(KeenConstants.QueryParmTimezone, timezone);
             parms.Add(KeenConstants.QueryParmFilters, filters == null ? "" : JArray.FromObject(filters).ToString());
-            parms.Add(KeenConstants.QueryParmAnalyses, parmsJson);
+            parms.Add(KeenConstants.QueryParmAnalyses, SerializeMultiAnalysisQueryParameter(analysisParams));
 
             var reply = await KeenWebApiRequest(KeenConstants.QueryMultiAnalysis, parms).ConfigureAwait(false);
 
@@ -343,24 +346,13 @@ namespace Keen.Core.Query
 
         public async Task<IEnumerable<QueryGroupValue<IDictionary<string, string>>>> MultiAnalysis(string collection, IEnumerable<MultiAnalysisParam> analysisParams, IQueryTimeframe timeframe = null, IEnumerable<QueryFilter> filters = null, string groupby = "", string timezone = "")
         {
-            var jObs = analysisParams.Select(x =>
-                new JProperty(x.Label, JObject.FromObject(
-                    string.IsNullOrEmpty(x.TargetProperty) ?
-                        (object)new { analysis_type = x.Analysis } :
-                        new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
-
-            var parmsJson = JsonConvert.SerializeObject(
-                new JObject(jObs),
-                Formatting.None,
-                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-
             var parms = new Dictionary<string, string>();
             parms.Add(KeenConstants.QueryParmEventCollection, collection);
             parms.Add(KeenConstants.QueryParmTimeframe, timeframe.ToSafeString());
             parms.Add(KeenConstants.QueryParmTimezone, timezone);
             parms.Add(KeenConstants.QueryParmFilters, filters == null ? "" : JArray.FromObject(filters).ToString());
             parms.Add(KeenConstants.QueryParmGroupBy, groupby);
-            parms.Add(KeenConstants.QueryParmAnalyses, parmsJson);
+            parms.Add(KeenConstants.QueryParmAnalyses, SerializeMultiAnalysisQueryParameter(analysisParams));
 
             var reply = await KeenWebApiRequest(KeenConstants.QueryMultiAnalysis, parms).ConfigureAwait(false);
 
@@ -385,16 +377,13 @@ namespace Keen.Core.Query
 
         public async Task<IEnumerable<QueryIntervalValue<IDictionary<string, string>>>> MultiAnalysis(string collection, IEnumerable<MultiAnalysisParam> analysisParams, IQueryTimeframe timeframe = null, QueryInterval interval = null, IEnumerable<QueryFilter> filters = null, string timezone = "")
         {
-            var jObs = analysisParams.Select(x => new JProperty(x.Label, JObject.FromObject(new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
-            var parmsJson = JsonConvert.SerializeObject(new JObject(jObs), Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-
             var parms = new Dictionary<string, string>();
             parms.Add(KeenConstants.QueryParmEventCollection, collection);
             parms.Add(KeenConstants.QueryParmTimeframe, timeframe.ToSafeString());
             parms.Add(KeenConstants.QueryParmInterval, interval.ToSafeString());
             parms.Add(KeenConstants.QueryParmTimezone, timezone);
             parms.Add(KeenConstants.QueryParmFilters, filters == null ? "" : JArray.FromObject(filters).ToString());
-            parms.Add(KeenConstants.QueryParmAnalyses, parmsJson);
+            parms.Add(KeenConstants.QueryParmAnalyses, SerializeMultiAnalysisQueryParameter(analysisParams));
 
             var reply = await KeenWebApiRequest(KeenConstants.QueryMultiAnalysis, parms).ConfigureAwait(false);
 
@@ -415,9 +404,6 @@ namespace Keen.Core.Query
 
         public async Task<IEnumerable<QueryIntervalValue<IEnumerable<QueryGroupValue<IDictionary<string, string>>>>>> MultiAnalysis(string collection, IEnumerable<MultiAnalysisParam> analysisParams, IQueryTimeframe timeframe = null, QueryInterval interval = null, IEnumerable<QueryFilter> filters = null, string groupby = "", string timezone = "")
         {
-            var jObs = analysisParams.Select(x => new JProperty(x.Label, JObject.FromObject(new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
-            var parmsJson = JsonConvert.SerializeObject(new JObject(jObs), Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-
             var parms = new Dictionary<string, string>();
             parms.Add(KeenConstants.QueryParmEventCollection, collection);
             parms.Add(KeenConstants.QueryParmTimeframe, timeframe.ToSafeString());
@@ -425,7 +411,7 @@ namespace Keen.Core.Query
             parms.Add(KeenConstants.QueryParmTimezone, timezone);
             parms.Add(KeenConstants.QueryParmGroupBy, groupby);
             parms.Add(KeenConstants.QueryParmFilters, filters == null ? "" : JArray.FromObject(filters).ToString());
-            parms.Add(KeenConstants.QueryParmAnalyses, parmsJson);
+            parms.Add(KeenConstants.QueryParmAnalyses, SerializeMultiAnalysisQueryParameter(analysisParams));
 
             var reply = await KeenWebApiRequest(KeenConstants.QueryMultiAnalysis, parms).ConfigureAwait(false);
 

--- a/Keen.NetStandard/Query/Queries.cs
+++ b/Keen.NetStandard/Query/Queries.cs
@@ -344,8 +344,15 @@ namespace Keen.Core.Query
         public async Task<IEnumerable<QueryGroupValue<IDictionary<string, string>>>> MultiAnalysis(string collection, IEnumerable<MultiAnalysisParam> analysisParams, IQueryTimeframe timeframe = null, IEnumerable<QueryFilter> filters = null, string groupby = "", string timezone = "")
         {
             var jObs = analysisParams.Select(x =>
-                new JProperty(x.Label, JObject.FromObject(new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
-            var parmsJson = JsonConvert.SerializeObject(new JObject(jObs), Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+                new JProperty(x.Label, JObject.FromObject(
+                    string.IsNullOrEmpty(x.TargetProperty) ?
+                        (object)new { analysis_type = x.Analysis } :
+                        new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
+
+            var parmsJson = JsonConvert.SerializeObject(
+                new JObject(jObs),
+                Formatting.None,
+                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
 
             var parms = new Dictionary<string, string>();
             parms.Add(KeenConstants.QueryParmEventCollection, collection);

--- a/Keen.NetStandard/Query/QueryAbsoluteTimeframe.cs
+++ b/Keen.NetStandard/Query/QueryAbsoluteTimeframe.cs
@@ -21,6 +21,22 @@ namespace Keen.Core.Query
             return JObject.FromObject(this).ToString(Formatting.None);
         }
 
+        public override bool Equals(object obj)
+        {
+            var timeframe = obj as QueryAbsoluteTimeframe;
+            return timeframe != null &&
+                   Start == timeframe.Start &&
+                   End == timeframe.End;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1676728671;
+            hashCode = hashCode * -1521134295 + Start.GetHashCode();
+            hashCode = hashCode * -1521134295 + End.GetHashCode();
+            return hashCode;
+        }
+
         public QueryAbsoluteTimeframe(DateTime start, DateTime end)
         {
             if (start >= end)

--- a/Keen.NetStandard/Query/QueryGroupValue.cs
+++ b/Keen.NetStandard/Query/QueryGroupValue.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Collections.Generic;
+
 namespace Keen.Core.Query
 {
     /// <summary>
@@ -21,6 +23,22 @@ namespace Keen.Core.Query
         {
             Value = value;
             Group = group;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var value = obj as QueryGroupValue<T>;
+            return value != null &&
+                   EqualityComparer<T>.Default.Equals(Value, value.Value) &&
+                   Group == value.Group;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1845644250;
+            hashCode = hashCode * -1521134295 + EqualityComparer<T>.Default.GetHashCode(Value);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Group);
+            return hashCode;
         }
     }
 }

--- a/Keen.NetStandard/Query/QueryIntervalValue.cs
+++ b/Keen.NetStandard/Query/QueryIntervalValue.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+using System.Collections.Generic;
 
 namespace Keen.Core.Query
 {
@@ -29,6 +29,24 @@ namespace Keen.Core.Query
             Value = value;
             Start = start;
             End = end;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var value = obj as QueryIntervalValue<T>;
+            return value != null &&
+                   value.Value.Equals(Value) &&
+                   Start == value.Start &&
+                   End == value.End;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1158026325;
+            hashCode = hashCode * -1521134295 + EqualityComparer<T>.Default.GetHashCode(Value);
+            hashCode = hashCode * -1521134295 + Start.GetHashCode();
+            hashCode = hashCode * -1521134295 + End.GetHashCode();
+            return hashCode;
         }
     }
 }

--- a/Keen.NetStandard/Query/QueryRelativeTimeframe.cs
+++ b/Keen.NetStandard/Query/QueryRelativeTimeframe.cs
@@ -1,5 +1,5 @@
 ﻿using Newtonsoft.Json;
-
+using System.Collections.Generic;
 
 namespace Keen.Core.Query
 {
@@ -206,5 +206,17 @@ namespace Keen.Core.Query
         /// convenience for “previous_1_years”
         /// </summary>
         public static QueryRelativeTimeframe PreviousYear() { return Create("previous_year"); }
+
+        public override bool Equals(object obj)
+        {
+            var timeframe = obj as QueryRelativeTimeframe;
+            return timeframe != null &&
+                   _value == timeframe._value;
+        }
+
+        public override int GetHashCode()
+        {
+            return -1939223833 + EqualityComparer<string>.Default.GetHashCode(_value);
+        }
     }
 }

--- a/Keen.NetStandard/Query/TimeframeConverter.cs
+++ b/Keen.NetStandard/Query/TimeframeConverter.cs
@@ -46,7 +46,7 @@ namespace Keen.Core.Query
             // absolute timeframe.
             if (JTokenType.String == jsonToken.Type)
             {
-                return QueryRelativeTimeframe.Create(jsonToken.ToString(Formatting.None));
+                return QueryRelativeTimeframe.Create(jsonToken.ToString(Formatting.None).Replace("\"", ""));
             }
             else
             {

--- a/Keen.NetStandard/Query/TimeframeConverter.cs
+++ b/Keen.NetStandard/Query/TimeframeConverter.cs
@@ -46,7 +46,7 @@ namespace Keen.Core.Query
             // absolute timeframe.
             if (JTokenType.String == jsonToken.Type)
             {
-                return QueryRelativeTimeframe.Create(jsonToken.ToString(Formatting.None).Replace("\"", ""));
+                return QueryRelativeTimeframe.Create(jsonToken.Value<string>());
             }
             else
             {

--- a/Keen/Query/MultiAnalysisParam.cs
+++ b/Keen/Query/MultiAnalysisParam.cs
@@ -7,8 +7,8 @@ namespace Keen.Core.Query
         {
             private readonly string _value;
             public readonly string TargetProperty;
-            private Metric(string value) { _value = value; }
-            private Metric(string value, string targetProperty) { _value = value; TargetProperty = targetProperty;  }
+            internal Metric(string value) { _value = value; }
+            internal Metric(string value, string targetProperty) { _value = value; TargetProperty = targetProperty;  }
             public override string ToString() { return _value; }
             public static implicit operator string(Metric value) { return value.ToString(); }
 

--- a/Keen/Query/Queries.cs
+++ b/Keen/Query/Queries.cs
@@ -99,17 +99,17 @@ namespace Keen.Core.Query
             var reply = await KeenWebApiRequest().ConfigureAwait(false);
             return from j in reply.Children()
                    let p = j as JProperty
-                   where p != null 
+                   where p != null
                    select new KeyValuePair<string, string>(p.Name, (string)p.Value);
         }
 
         #region metric
 
-        public async Task<JObject> Metric(string queryName, Dictionary<string,string> parms)
+        public async Task<JObject> Metric(string queryName, Dictionary<string, string> parms)
         {
             if (string.IsNullOrEmpty(queryName))
                 throw new ArgumentNullException("queryName");
-            if (null==parms)
+            if (null == parms)
                 throw new ArgumentNullException("parms");
 
             return await KeenWebApiRequest(queryName, parms).ConfigureAwait(false);
@@ -303,7 +303,7 @@ namespace Keen.Core.Query
             {
                 parms.Add(KeenConstants.QueryParmTimeframe, timeframe.ToString());
             }
-            
+
             parms.Add(KeenConstants.QueryParmTimezone, timezone);
             parms.Add(KeenConstants.QueryParmSteps, stepsJson);
 
@@ -312,18 +312,28 @@ namespace Keen.Core.Query
             return o;
         }
 
+        string SerializeMultiAnalysisQueryParameter(IEnumerable<MultiAnalysisParam> analysisParams)
+        {
+            var jObs = analysisParams.Select(x =>
+                new JProperty(x.Label, JObject.FromObject(
+                    string.IsNullOrEmpty(x.TargetProperty) ?
+                        (object)new { analysis_type = x.Analysis } :
+                        new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
+
+            return JsonConvert.SerializeObject(
+                new JObject(jObs),
+                Formatting.None,
+                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+        }
+
         public async Task<IDictionary<string, string>> MultiAnalysis(string collection, IEnumerable<MultiAnalysisParam> analysisParams, IQueryTimeframe timeframe = null, IEnumerable<QueryFilter> filters = null, string timezone = "")
         {
-            var jObs = analysisParams.Select(x => 
-                new JProperty( x.Label, JObject.FromObject( new {analysis_type = x.Analysis, target_property = x.TargetProperty })));
-            var parmsJson = JsonConvert.SerializeObject(new JObject(jObs), Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-
             var parms = new Dictionary<string, string>();
             parms.Add(KeenConstants.QueryParmEventCollection, collection);
             parms.Add(KeenConstants.QueryParmTimeframe, timeframe.ToSafeString());
             parms.Add(KeenConstants.QueryParmTimezone, timezone);
             parms.Add(KeenConstants.QueryParmFilters, filters == null ? "" : JArray.FromObject(filters).ToString());
-            parms.Add(KeenConstants.QueryParmAnalyses, parmsJson);
+            parms.Add(KeenConstants.QueryParmAnalyses, SerializeMultiAnalysisQueryParameter(analysisParams));
 
             var reply = await KeenWebApiRequest(KeenConstants.QueryMultiAnalysis, parms).ConfigureAwait(false);
 
@@ -336,17 +346,13 @@ namespace Keen.Core.Query
 
         public async Task<IEnumerable<QueryGroupValue<IDictionary<string, string>>>> MultiAnalysis(string collection, IEnumerable<MultiAnalysisParam> analysisParams, IQueryTimeframe timeframe = null, IEnumerable<QueryFilter> filters = null, string groupby = "", string timezone = "")
         {
-            var jObs = analysisParams.Select(x =>
-                new JProperty(x.Label, JObject.FromObject(new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
-            var parmsJson = JsonConvert.SerializeObject(new JObject(jObs), Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-
             var parms = new Dictionary<string, string>();
             parms.Add(KeenConstants.QueryParmEventCollection, collection);
             parms.Add(KeenConstants.QueryParmTimeframe, timeframe.ToSafeString());
             parms.Add(KeenConstants.QueryParmTimezone, timezone);
             parms.Add(KeenConstants.QueryParmFilters, filters == null ? "" : JArray.FromObject(filters).ToString());
             parms.Add(KeenConstants.QueryParmGroupBy, groupby);
-            parms.Add(KeenConstants.QueryParmAnalyses, parmsJson);
+            parms.Add(KeenConstants.QueryParmAnalyses, SerializeMultiAnalysisQueryParameter(analysisParams));
 
             var reply = await KeenWebApiRequest(KeenConstants.QueryMultiAnalysis, parms).ConfigureAwait(false);
 
@@ -371,16 +377,13 @@ namespace Keen.Core.Query
 
         public async Task<IEnumerable<QueryIntervalValue<IDictionary<string, string>>>> MultiAnalysis(string collection, IEnumerable<MultiAnalysisParam> analysisParams, IQueryTimeframe timeframe = null, QueryInterval interval = null, IEnumerable<QueryFilter> filters = null, string timezone = "")
         {
-            var jObs = analysisParams.Select(x => new JProperty(x.Label, JObject.FromObject(new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
-            var parmsJson = JsonConvert.SerializeObject(new JObject(jObs), Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-
             var parms = new Dictionary<string, string>();
             parms.Add(KeenConstants.QueryParmEventCollection, collection);
             parms.Add(KeenConstants.QueryParmTimeframe, timeframe.ToSafeString());
             parms.Add(KeenConstants.QueryParmInterval, interval.ToSafeString());
             parms.Add(KeenConstants.QueryParmTimezone, timezone);
             parms.Add(KeenConstants.QueryParmFilters, filters == null ? "" : JArray.FromObject(filters).ToString());
-            parms.Add(KeenConstants.QueryParmAnalyses, parmsJson);
+            parms.Add(KeenConstants.QueryParmAnalyses, SerializeMultiAnalysisQueryParameter(analysisParams));
 
             var reply = await KeenWebApiRequest(KeenConstants.QueryMultiAnalysis, parms).ConfigureAwait(false);
 
@@ -392,7 +395,7 @@ namespace Keen.Core.Query
                     d.Add(p.Name, (string)p.Value);
 
                 var t = i.Value<JObject>("timeframe");
-                var qv = new QueryIntervalValue<IDictionary<string, string>>(d , t.Value<DateTime>("start"), t.Value<DateTime>("end"));
+                var qv = new QueryIntervalValue<IDictionary<string, string>>(d, t.Value<DateTime>("start"), t.Value<DateTime>("end"));
                 result.Add(qv);
             }
 
@@ -401,9 +404,6 @@ namespace Keen.Core.Query
 
         public async Task<IEnumerable<QueryIntervalValue<IEnumerable<QueryGroupValue<IDictionary<string, string>>>>>> MultiAnalysis(string collection, IEnumerable<MultiAnalysisParam> analysisParams, IQueryTimeframe timeframe = null, QueryInterval interval = null, IEnumerable<QueryFilter> filters = null, string groupby = "", string timezone = "")
         {
-            var jObs = analysisParams.Select(x => new JProperty(x.Label, JObject.FromObject(new { analysis_type = x.Analysis, target_property = x.TargetProperty })));
-            var parmsJson = JsonConvert.SerializeObject(new JObject(jObs), Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-
             var parms = new Dictionary<string, string>();
             parms.Add(KeenConstants.QueryParmEventCollection, collection);
             parms.Add(KeenConstants.QueryParmTimeframe, timeframe.ToSafeString());
@@ -411,7 +411,7 @@ namespace Keen.Core.Query
             parms.Add(KeenConstants.QueryParmTimezone, timezone);
             parms.Add(KeenConstants.QueryParmGroupBy, groupby);
             parms.Add(KeenConstants.QueryParmFilters, filters == null ? "" : JArray.FromObject(filters).ToString());
-            parms.Add(KeenConstants.QueryParmAnalyses, parmsJson);
+            parms.Add(KeenConstants.QueryParmAnalyses, SerializeMultiAnalysisQueryParameter(analysisParams));
 
             var reply = await KeenWebApiRequest(KeenConstants.QueryMultiAnalysis, parms).ConfigureAwait(false);
 
@@ -430,7 +430,7 @@ namespace Keen.Core.Query
                         else
                             d.Add(p.Name, (string)p.Value);
                     }
-                    qgl.Add( new QueryGroupValue<IDictionary<string, string>>(d, grpVal));
+                    qgl.Add(new QueryGroupValue<IDictionary<string, string>>(d, grpVal));
                 }
 
                 var t = i.Value<JObject>("timeframe");

--- a/Keen/Query/TimeframeConverter.cs
+++ b/Keen/Query/TimeframeConverter.cs
@@ -46,7 +46,7 @@ namespace Keen.Core.Query
             // absolute timeframe.
             if (JTokenType.String == jsonToken.Type)
             {
-                return QueryRelativeTimeframe.Create(jsonToken.ToString(Formatting.None));
+                return QueryRelativeTimeframe.Create(jsonToken.ToString(Formatting.None).Replace("\"", ""));
             }
             else
             {

--- a/Keen/Query/TimeframeConverter.cs
+++ b/Keen/Query/TimeframeConverter.cs
@@ -46,7 +46,7 @@ namespace Keen.Core.Query
             // absolute timeframe.
             if (JTokenType.String == jsonToken.Type)
             {
-                return QueryRelativeTimeframe.Create(jsonToken.ToString(Formatting.None).Replace("\"", ""));
+                return QueryRelativeTimeframe.Create(jsonToken.Value<string>());
             }
             else
             {


### PR DESCRIPTION
This tests a bunch of code that previously wasn't tested in automation. For this round I focused on getting all types of queries tested with some basic tests. More tests still need to be added to cover other parts of the SDK, but this was a major area that needed work. Takes code coverage from 57% to 70%.

It's interesting that some of the abstractions that came around like QueryParameters reflect some of the ideas that have been discussed around reshaping the SDK surface by getting rid of all of the different overloads of Metric, etc. I'd like to see something even more generic, and I'd bet we can reduce Queries.cs to possibly even a single generic method that takes a QueryParameters type object and uses Json.Net to deserialize results into concrete types where we use JsonConverters where those types need to be transformed in some way.