### PR TITLE
Turn on automatic generation of the XML Doc comment file, which gets …

### DIFF
--- a/Keen/Keen.csproj
+++ b/Keen/Keen.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>David Knaack, Brian Baumhover, Justin Mason</Authors>
     <Version>0.4.0</Version>
     <Company>Keen IO</Company>


### PR DESCRIPTION
…included in the .nupkg now. So instead of this:

![withoutxmldoc](https://user-images.githubusercontent.com/11385690/32764868-d9b46138-c8d5-11e7-9c29-8ac211478f9b.png)

...now we get all this info using the SDK from a 3rd-party app/lib:
![withxmldoc](https://user-images.githubusercontent.com/11385690/32764869-d9d00ce4-c8d5-11e7-910f-499e959b7bd3.png)
