### PR TITLE
Add the <Title/> to the .csproj

### DIFF
--- a/Keen/Keen.csproj
+++ b/Keen/Keen.csproj
@@ -3,11 +3,17 @@
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Title>Keen.IO Client - .Net SDK</Title>
     <Authors>David Knaack, Brian Baumhover, Justin Mason</Authors>
     <Version>0.4.0</Version>
     <Company>Keen IO</Company>
     <Product>Keen IO .NET SDK</Product>
     <Description>Keen IO is an analytics API for modern developers. Track any event: signups, upgrades, impressions, purchases, powerups, errors, shares... Keen IO stores events in arbitrary JSON format, automatically ingesting any new events and rich custom properties you send. Our elegant query APIs make it straightforward to run counts, sums, segmentation, and more.</Description>
+    <!-- NOTE: Summary used to be in the .nuspec as "Keen IO is an analytics API that stores events in arbitrary JSON format."
+         However, Summary may be getting deprecated and isn't supported in the new .csproj even though NuGet.org still
+         uses it. The tools may still show a "warning : Issue: Consider providing Summary text" which can't really be fixed
+         right now as per https://github.com/NuGet/Home/issues/4587 so if we want a "Summary" field in NuGet.org, we have to
+         edit the package after pushing it. -->
     <Copyright>Copyright © 2014 Keen IO</Copyright>
     <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
     <PackageProjectUrl>https://keen.io/</PackageProjectUrl>


### PR DESCRIPTION
This affects what gets emitted in the .nuspec and what's shown in the UI, like on NuGet.org and in the Visual Studio package manager. It used to be there when we had the .nuspec and we just missed it when converting over to .csproj-based nuget packaging.

I updated the Title on NuGet.org for 0.4.0 so this can sit in `master` until the next time we want to push to NuGet without issue.

I also added a comment which may or may not still be applicable, but it was in my notes...if we find the "Summary" is officially dead at some point and the tools stop issuing that warning, we can remove that in the future.